### PR TITLE
COUCHDB_PORT port needs to be a string for Heroku to deploy correctly

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
     },
     "COUCHDB_PORT":{
       "description":"CouchDb port",
-      "value":443
+      "value":"443"
     },
     "COUCHDB_NAME":{
       "description":"",


### PR DESCRIPTION
Pull request: https://github.com/pebblecode/wfh-api/issues/6
